### PR TITLE
Fix HoloPlayCore path definition

### DIFF
--- a/looking_glass_tools/__init__.py
+++ b/looking_glass_tools/__init__.py
@@ -231,10 +231,10 @@ def register():
 		if sys.startswith('Darwin'):
 			print("Running on Mac OS")
 			# convert from PosixPath to string before storing in preferences
-			filepath = str(home / "Library/Application Support" / lkgFolderName / lkgSubFolderName / "libHoloPlayCore.dylib")
+			filepath = str(str(home) + "/Library/Application Support/" + lkgFolderName + "/" + lkgSubFolderName + "/libHoloPlayCore.dylib")
 			# the holoplay library might also reside in the local library
 			if not os.path.exists(filepath):
-				filepath = str("/Library/Application Support" / lkgFolderName / lkgSubFolderName / "libHoloPlayCore.dylib")
+				filepath = str("/Library/Application Support/" + lkgFolderName + "/" + lkgSubFolderName + "/libHoloPlayCore.dylib")
 			bpy.context.preferences.addons['looking_glass_tools'].preferences.filepath = filepath
 		elif sys.startswith('Windows'):
 			print("Running on Windows")


### PR DESCRIPTION
Running macOS 11.2.3, I got the following error when trying to activate the Blender plugin:

> Line 237: "TypeError: unsupported operand type(s) for /: 'str' and 'str'

I believe the prior convention would have worked if a path were being defined, but in this case of string concatenation, the slashes must be in quotation marks.

Also, the `home` variable must be independently converted to a string before concatenating it.

I imagine a similar change must be applied to the Windows section (line 241) and the Linux section (line 245), but I didn't make those changes here as I have no way to test them.